### PR TITLE
Corrected repo link to be relative.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "zocial"]
 	path = zocial
-	url = https://github.com/EzerIT/css-social-buttons
+	url = ../css-social-buttons
 [submodule "jstree"]
 	path = jstree
-	url = https://github.com/EzerIT/jstree
+	url = ../jstree
+


### PR DESCRIPTION
This request changes the git sub-modules to be relative.

Now, you can recursively check out the repo both with

```shell
git clone --recursive https://github.com/EzerIT/BibleOL.git
```

as well as 

```shell
git clone --recursive git@github.com:EzerIT/BibleOL.git
```
