### PR TITLE
Hide Yellow Shadow on Exercises Panel and My View Panel

### DIFF
--- a/styles/ol.css
+++ b/styles/ol.css
@@ -400,11 +400,11 @@ div#grammargroup {
 }
 .ui-tabs .ui-tabs-nav .ui-state-default {
   border: none;
-  padding-right: 5px;
+  padding-right: 0px;
 }
 .ui-tabs .ui-tabs-nav .ui-state-active {
   border: none;
-  padding-right: 5px;
+  padding-right: 0px;
 }
 .ui-tabs .ui-tabs-nav .ui-state-active #myview {
   border-bottom: 0px !important;


### PR DESCRIPTION
There are yellow shadows in two places on the system that need to be removed. 

The first occurrence is when an exercise is being created:
<img width="883" alt="Screenshot 2023-12-24 at 1 21 43 PM" src="https://github.com/EzerIT/BibleOL/assets/60988784/ddd28342-ab2e-45f4-9dc0-a0aee4c7d3e2">

The second occurrence is when a student is taking an exam or exercise and clicks on "My View":
<img width="809" alt="Screenshot 2023-12-24 at 1 25 47 PM" src="https://github.com/EzerIT/BibleOL/assets/60988784/97eec584-deb3-4932-9ada-f11a58b73d96">

To remove these shadows I changed the padding-right attribute of .ui-tabs in ol.css:401 and ol.css:405 from 5px to 0px:
```
.ui-tabs .ui-tabs-nav .ui-state-default {
  border: none;
  padding-right: 0px;
}
.ui-tabs .ui-tabs-nav .ui-state-active {
  border: none;
  padding-right: 0px;
}
```

The edit deletes the yellow shadows:

<img width="1242" alt="Screenshot 2023-12-24 at 1 29 23 PM" src="https://github.com/EzerIT/BibleOL/assets/60988784/e815f363-7ccb-4407-9ba3-79b185ce54c7">

<img width="564" alt="Screenshot 2023-12-24 at 1 28 39 PM" src="https://github.com/EzerIT/BibleOL/assets/60988784/73f862d3-8f47-4301-9137-77a0832a80d5">
